### PR TITLE
Added mutations to config object

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ pip install torch torchvision
 cd basic
 ```
 
-- [`main.py`](basic/main.py): entrypoint script with argparse accepts a configuration file and 
+- [`main.py`](basic/main.py): entrypoint script with argparse accepts a configuration file and
 uses `py_config_runner.ConfigObject` to parse python configuration file.
 
 - [`training.py`](basic/training.py): module defines `run` method and how configuration is consumed.
@@ -40,7 +40,7 @@ py_config_runner training.py configs/baseline_train.py
 cd pytorch
 ```
 
-- [`main.py`](pytorch/main.py): entrypoint script with argparse accepts a configuration file and 
+- [`main.py`](pytorch/main.py): entrypoint script with argparse accepts a configuration file and
 uses `py_config_runner.ConfigObject` to parse python configuration file.
 
 - [`training.py`](pytorch/training.py): module defines `run` method and how configuration is consumed.

--- a/examples/pytorch/configs/baseline_train_pytorch.py
+++ b/examples/pytorch/configs/baseline_train_pytorch.py
@@ -25,7 +25,9 @@ train_loader, val_loader = get_mnist_data_loaders(
 model = resnet18(num_classes=10)
 model.conv1 = nn.Conv2d(1, 64, 3)
 
-optimizer = SGD(model.parameters(), lr=0.01)
+learning_rate = 0.01
+
+optimizer = SGD(model.parameters(), lr=learning_rate)
 criterion = nn.CrossEntropyLoss()
 
 num_epochs = 5

--- a/examples/pytorch/main.py
+++ b/examples/pytorch/main.py
@@ -10,14 +10,29 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser("Example application")
     parser.add_argument("--config", type=Path, help="Input configuration file")
+    parser.add_argument("--bs", type=int, default=None, help="Override train batch size")
+    parser.add_argument("--lr", type=float, default=None, help="Override train learning rate")
+    parser.add_argument("--ep", type=int, default=None, help="Override number of epochs")
     args = parser.parse_args()
 
     assert args.config is not None
     assert args.config.exists()
 
+    # Define configuration mutations if certain cmd args are defined
+    mutations = {}
+    if args.bs is not None:
+        mutations["train_batch_size"] = args.bs
+    if args.lr is not None:
+        mutations["learning_rate"] = args.lr
+    if args.ep is not None:
+        mutations["num_epochs"] = args.ep
+
+    if len(mutations) < 1:
+        mutations = None
+
     # Pass configuration file into py_config_runner.ConfigObject
     # and fetch configuration parameters as attributes
     # see inside run() function
-    config = ConfigObject(args.config)
+    config = ConfigObject(args.config, mutations=mutations)
 
     run(config)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,6 +77,77 @@ def test_config_object_init_kwargs(config_filepath):
     assert config.another_data == 123
 
 
+def test_config_object_lazy_load(dirname):
+    filepath = os.path.join(dirname, "bad_config.py")
+
+    s = """
+a = 123
+
+raise RuntimeError("error")
+    """
+
+    with open(filepath, "w") as h:
+        h.write(s)
+
+    config = ConfigObject(filepath)
+
+    with pytest.raises(RuntimeError, match=r"error"):
+        assert config.a == 123
+
+
+def test_config_object_mutations(dirname):
+    filepath = os.path.join(dirname, "custom_module.py")
+
+    s = """
+
+a = 123
+b = 12.3
+c = "abc"
+d = True
+# e = None
+
+
+def func(x):
+    return x + a
+
+out = func(10)
+
+def func2(x):
+    return x + b
+
+out2 = func2(1.0)
+
+
+def func3(x):
+    if x == "abc":
+        return 1.0
+    elif x == "cba":
+        return -1.0
+    else:
+        return 0.0
+
+out3 = func3(c)
+
+
+out4 = 10 if d else -10
+# out5 = 10 if e is None else -10
+    """
+
+    with open(filepath, "w") as h:
+        h.write(s)
+
+    config = ConfigObject(filepath, mutations={"a": 333, "b": 22.0, "c": "cba", "d": False})
+
+    assert config.a == 333
+    assert config.out == 10 + 333
+    assert config.b == 22.0
+    assert config.out2 == 1.0 + 22.0
+    assert config.c == "cba"
+    assert config.out3 == -1.0
+    assert not config.d
+    assert config.out4 == -10
+
+
 def test_load_module(dirname):
     import numpy as np
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 
 from py_config_runner import ConfigObject, load_module
+from py_config_runner.utils import _ConstMutatorPy37
 
 
 def test_config_object(config_filepath):
@@ -148,6 +149,28 @@ out4 = 10 if d else -10
     assert config.out4 == -10
 
 
+def test_config_object_mutations_validate(dirname):
+    filepath = os.path.join(dirname, "custom_module.py")
+
+    s = """
+
+a = 123
+
+def func(x):
+    return x + a
+
+out = func(10)
+    """
+
+    with open(filepath, "w") as h:
+        h.write(s)
+
+    config = ConfigObject(filepath, mutations={"a": 333, "b": 22.0})
+
+    with pytest.raises(RuntimeError, match=r"Following mutations were not applied"):
+        assert config.a == 333
+
+
 def test_load_module(dirname):
     import numpy as np
 
@@ -177,3 +200,26 @@ def test_load_module_wrong_args():
 
     with pytest.raises(ValueError, match=r"should be a file"):
         load_module("/tmp/")
+
+
+def test__ConstMutatorPy37():
+    import ast
+
+    config_source = """
+a = 1
+b = 1.0
+c = True
+d = "abc"
+    """
+
+    ast_obj = ast.parse(config_source)
+
+    mutations = {"a": 12, "b": 3.4, "c": False, "d": "cba"}
+    mutator = _ConstMutatorPy37(mutations)
+    mutator.visit(ast_obj)
+
+    ast_obj_str = ast.dump(ast_obj)
+    assert "=12" in ast_obj_str
+    assert "=3.4" in ast_obj_str
+    assert "=False" in ast_obj_str
+    assert "='cba'" in ast_obj_str


### PR DESCRIPTION
Let's assume that configuration python file has ``learning_rate = 0.01`` which is used to configure an optimizer:

```python
# baseline.py configuration file

learning_rate = 0.01

optimizer = SGD(parameters, lr=learning_rate)
```

And we would like to override ``learning_rate`` from the script using above configuration file and has also optimizer updated accordingly:

```python

# Script file using baseline.py configuration

config = ConfigObject("/path/to/baseline.py", mutations={"learning_rate": 0.05})
print(config)
print(config.optimizer)
# assert config.optimizer.lr == 0.05
```

Working example: 
- https://github.com/vfdev-5/py_config_runner/blob/20122917ed6425644d424d571f147f74d0a7d17a/examples/pytorch/main.py


TODO:
- [x] Update docs that only constant mutations are possible
- [x] Raise error if not all mutations were used
- [ ] Optionally, save new config as a new file (?) check `unparse`
  - `ast.unparse` is available since python 3.9
  - [unparse demo](https://github.com/python/cpython/blob/3.8/Tools/parser/unparse.py)
- [x] Optionally, improve codecov
