### PR TITLE
Mutations can change types

### DIFF
--- a/py_config_runner/utils.py
+++ b/py_config_runner/utils.py
@@ -193,7 +193,7 @@ class _ConstMutator(ast.NodeTransformer):
                 raise ValueError(base_err_msg + f"Value AST body is empty: {value_ast.body}")
             if not hasattr(value_ast.body[0], "value"):
                 raise ValueError(base_err_msg + f"Value AST body[0] has no 'value': {value_ast.body[0]}")
-            output[key] = value_ast.body[0].value
+            output[key] = value_ast.body[0].value  # type: ignore[attr-defined]
         return output
 
     def __init__(self, mutations_ast: Mapping):


### PR DESCRIPTION
Now user can do:
```python
old_value = {"encoder": "E1", "decoder": "D1"} 
# old_value = "unet"
# old_value = [1, 2, 3]
# old_value = 5

new_value = "unet"
# new_value = [1, 2, 3]
# new_value = {"encoder": "E1", "decoder": "D1"}
# new_value = 5

# Create a configuration file:
filepath = os.path.join(dirname, "custom_module.py")
s = f"""
a = {old_value}
"""

with open(filepath, "w") as h:
   h.write(s)

# Load configuration:
config = ConfigObject(filepath, mutations={"a": new_value})
assert config.a == new_value
```

cc @DhDeepLIT